### PR TITLE
Fix pointer causing random crashes

### DIFF
--- a/Gdip_All.ahk
+++ b/Gdip_All.ahk
@@ -2526,7 +2526,7 @@ Gdip_ResetClip(pGraphics)
 Gdip_GetClipRegion(pGraphics)
 {
 	Region := Gdip_CreateRegion()
-	DllCall("gdiplus\GdipGetClip", A_PtrSize ? "UPtr" : "UInt", pGraphics, "UInt*", Region)
+	DllCall("gdiplus\GdipGetClip", A_PtrSize ? "UPtr" : "UInt", pGraphics, "UInt", Region)
 	return Region
 }
 


### PR DESCRIPTION
Annoying bug that's due to improper wrapping. Causes crashes randomly, I can't tell what inputs cause it to crash, but this does fix it. 

From documentation:
GpStatus WINGDIPAPI GdipGetClip(GpGraphics *graphics, GpRegion *region)

region should be a pointer, not a dereferenced pointer. 