### PR TITLE
Gdip_BitmapFromBase64() added.

### DIFF
--- a/Gdip_All.ahk
+++ b/Gdip_All.ahk
@@ -770,7 +770,6 @@ Gdip_BitmapFromBRA(ByRef BRAFromMemIn, File, Alternate := 0) {
 ; Function:				Gdip_BitmapFromBase64
 ; Description:			Creates a bitmap from a Base64 encoded string
 ;
-; pBitmap				Pointer to a bitmap
 ; Base64				ByRef variable. Base64 encoded string. Immutable, ByRef to avoid performance overhead of passing long strings.
 ;
 ; return				If the function succeeds, the return value is a pointer to a bitmap, otherwise:


### PR DESCRIPTION
credit: https://autohotkey.com/boards/viewtopic.php?f=76&t=49849#p221345

rewritten in a style comparable to other gdip functions.
opted not to prepend it with _"Create"_, to avoid naming inconsistencies whenever the complimentary `BitmapToBase64` eventually gets pushed in

an alternative could have been `<Decode/Encode>Bitmap<From/To>Base64` but thats a mouthful