### PR TITLE
Update Gdip_All.ahk

### DIFF
--- a/Gdip_All.ahk
+++ b/Gdip_All.ahk
@@ -521,7 +521,7 @@ CreateDIBSection(w, h, hdc:="", bpp:=32, ByRef ppvBits:=0)
 PrintWindow(hwnd, hdc, Flags:=0)
 {
 	Ptr := A_PtrSize ? "UPtr" : "UInt"
-
+	Flags |= 2	;PW_RENDERFULLCONTENT = $00000002
 	return DllCall("PrintWindow", Ptr, hwnd, Ptr, hdc, "uint", Flags)
 }
 


### PR DESCRIPTION
https://www.autohotkey.com/boards/viewtopic.php?t=64389
sixzeros
"For others getting this problem on win10 . try modifying the PrintWindow function in Gdip_all.ahk to add the RENDERFULLCONTENT flag."

This prevents GDI+ from getting a solid black image in some (NON-Fullscreen) windows.